### PR TITLE
set devise parent_mailer

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -27,7 +27,7 @@ Devise.setup do |config|
   config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.parent_mailer = 'ApplicationMailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'


### PR DESCRIPTION
hey, thanks for the project.

New Rails applications come with `ApplicationMailer`, it needs to be set otherwise `layouts/mailer.html.haml` won't be used.